### PR TITLE
[http client] Limit connections

### DIFF
--- a/aQute.libg/src/aQute/lib/consoleapp/packageinfo
+++ b/aQute.libg/src/aQute/lib/consoleapp/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.0.1

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/http/HttpClientTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/http/HttpClientTest.java
@@ -1,4 +1,4 @@
-package aQute.bnd.comm.tests;
+package aQute.bnd.http;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,14 +10,17 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.osgi.util.promise.Promise;
 
 import aQute.bnd.connection.settings.ConnectionSettings;
-import aQute.bnd.http.HttpClient;
-import aQute.bnd.http.URLCache;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.progress.ProgressPlugin;
@@ -71,6 +74,24 @@ public class HttpClientTest extends TestCase {
 				return "ok";
 			}
 		}
+
+		AtomicInteger n = new AtomicInteger();
+
+		public void _solitary(Request rq, Response rsp, int max, int id) throws Exception {
+			int x = n.incrementAndGet();
+			System.out.println("entering solitary " + id + " max = " + max + " n=" + x);
+			try {
+				if (x > max) {
+					rsp.code = 400;
+					return;
+				}
+				Thread.sleep(200);
+			} finally {
+				System.out.println("leaving solitary " + id + " max = " + max + " n=" + x);
+				n.decrementAndGet();
+			}
+		}
+
 	}
 
 	@Override
@@ -585,5 +606,57 @@ public class HttpClientTest extends TestCase {
 				assertTrue(done.get());
 			}
 		}
+	}
+
+	public void testLimitConnectionSet() throws Exception {
+		try (Processor p = new Processor()) {
+			p.setProperty("-x-max-concurrent-connections", "55");
+			try (HttpClient client = new HttpClient()) {
+				client.readSettings(p);
+				assertThat(client.maxConcurrentConnections).isEqualTo(55);
+			}
+		}
+	}
+
+	public void testLimitConnections() throws Exception {
+		try (Processor p = new Processor()) {
+			try (HttpClient client = new HttpClient()) {
+				client.maxConcurrentConnections = 3;
+				xtestParallel(client, 3);
+			}
+		}
+	}
+
+	AtomicInteger id = new AtomicInteger(1000);
+	private void xtestParallel(HttpClient client, int max) {
+		System.out.println("testing with max " + max);
+		List<CompletableFuture<TaggedData>> fs = new ArrayList<>();
+		for (int n = 0; n < 10; n++) {
+			int local = id.getAndIncrement();
+			CompletableFuture<TaggedData> f = CompletableFuture.supplyAsync(() -> {
+				try {
+					TaggedData tag = client.build()
+						.timeout(5000)
+						.asTag()
+						.go(httpServer.getBaseURI("solitary/" + max + "/" + local));
+					System.out.println("response " + tag.getResponseCode() + " Local " + local);
+					return tag;
+				} catch (Exception e) {
+					throw new RuntimeException();
+				}
+			});
+			fs.add(f);
+		}
+
+		fs.forEach(tag -> {
+			try {
+				TaggedData d = tag.get();
+				assertThat(d).isNotNull();
+				TaggedData taggedData = tag.get();
+				assertThat(taggedData.getResponseCode()).isEqualTo(200);
+			} catch (InterruptedException | ExecutionException e) {
+				throw new RuntimeException();
+			}
+		});
 	}
 }

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/http/HttpClientTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/http/HttpClientTest.java
@@ -608,6 +608,15 @@ public class HttpClientTest extends TestCase {
 		}
 	}
 
+	public void testNoLimitConnection() throws Exception {
+		try (Processor p = new Processor()) {
+			try (HttpClient client = new HttpClient()) {
+				client.maxConcurrentConnections = 0;
+				xtestParallel(client, 100);
+			}
+		}
+	}
+
 	public void testLimitConnectionSet() throws Exception {
 		try (Processor p = new Processor()) {
 			p.setProperty("-x-max-concurrent-connections", "55");

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
@@ -79,21 +81,23 @@ public class HttpClient implements Closeable, URLConnector {
 		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 	// These are not in HttpURLConnection
-	private static final int					HTTP_TEMPORARY_REDIRECT	= 307;					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
-	private static final int					HTTP_PERMANENT_REDIRECT	= 308;					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
+	private static final int					HTTP_TEMPORARY_REDIRECT		= 307;						// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
+	private static final int					HTTP_PERMANENT_REDIRECT		= 308;						// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
 
-	private final List<ProxyHandler>			proxyHandlers			= new ArrayList<>();
-	private final List<URLConnectionHandler>	connectionHandlers		= new ArrayList<>();
-	private ThreadLocal<PasswordAuthentication>	passwordAuthentication	= new ThreadLocal<>();
+	private final List<ProxyHandler>			proxyHandlers				= new ArrayList<>();
+	private final List<URLConnectionHandler>	connectionHandlers			= new ArrayList<>();
+	private ThreadLocal<PasswordAuthentication>	passwordAuthentication		= new ThreadLocal<>();
 	private boolean								inited;
-	private static JSONCodec					codec					= new JSONCodec();
-	private URLCache							cache					= new URLCache(
+	private static JSONCodec					codec						= new JSONCodec();
+	private URLCache							cache						= new URLCache(
 		IO.getFile(Home.getUserHomeBnd() + "/urlcache"));
-	private Registry							registry				= null;
+	private Registry							registry					= null;
 	private Reporter							reporter;
 	private volatile AtomicBoolean				offline;
 	private final PromiseFactory				promiseFactory;
 	private ConnectionSettings					connectionSettings;
+	final Map<String, Semaphore>				blocker						= new ConcurrentHashMap<>();
+	int											maxConcurrentConnections	= 40;
 
 	public HttpClient() {
 		promiseFactory = Processor.getPromiseFactory();
@@ -383,10 +387,12 @@ public class HttpClient implements Closeable, URLConnector {
 		} else {
 			task = new ProgressPlugin.Task() {
 				@Override
-				public void worked(int units) {}
+				public void worked(int units) {
+				}
 
 				@Override
-				public void done(String message, Throwable e) {}
+				public void done(String message, Throwable e) {
+				}
 
 				@Override
 				public boolean isCanceled() {
@@ -494,8 +500,7 @@ public class HttpClient implements Closeable, URLConnector {
 			con.setConnectTimeout(120000);
 			con.setReadTimeout(60000);
 		}
-
-		try {
+		try (AutoCloseable semaphore = getConnectionBlocker(hcon)) {
 
 			if (hcon == null) {
 				// not http
@@ -564,6 +569,27 @@ public class HttpClient implements Closeable, URLConnector {
 			task.done(ste.toString(), null);
 			return new TaggedData(request.url.toURI(), HTTP_GATEWAY_TIMEOUT, request.useCacheFile);
 		}
+	}
+
+	/*
+	 * Blocks on maxConcurrentConnections per host:port combination.
+	 */
+	private AutoCloseable getConnectionBlocker(HttpURLConnection hcon) throws InterruptedException {
+		if (hcon != null) {
+			URL url = hcon.getURL();
+			if (url != null) {
+				String host = url.getHost();
+				if (host != null) {
+					String key = host + ":" + url.getPort();
+					Semaphore s = blocker.computeIfAbsent(key, k -> new Semaphore(maxConcurrentConnections));
+					s.acquire();
+					return s::release;
+				}
+			}
+		}
+		return () -> {
+			// not blocked
+		};
 	}
 
 	boolean isUpdateInfo(final URLConnection con, HttpRequest<?> request, int code) {
@@ -707,6 +733,15 @@ public class HttpClient implements Closeable, URLConnector {
 	public void readSettings(Processor processor) throws IOException, Exception {
 		connectionSettings = new ConnectionSettings(processor, this);
 		connectionSettings.readSettings();
+		try {
+			String maxConcurrentConnections = processor.get("-x-max-concurrent-connections");
+			if (maxConcurrentConnections == null)
+				return;
+			this.maxConcurrentConnections = Integer.parseInt(maxConcurrentConnections);
+		} catch (Exception e) {
+			processor.error("-x-max-concurrent-connections is set to %s but this is not a proper integer",
+				maxConcurrentConnections);
+		}
 	}
 
 	public URI makeDir(URI uri) throws URISyntaxException {

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -16,7 +16,7 @@ Git-Descriptor:         ${system-allow-fail;git describe --dirty --always --abbr
 Git-SHA:                ${system-allow-fail;git rev-list -1 --no-abbrev-commit HEAD}
 
 # This is the version to baseline this build against.
-baseline.version:       4.2.0
+baseline.version:       4.2.1
 # biz.aQute.bndlib:aQute.bnd.osgi.About.CURRENT needs to be kept in sync with the base.version.
 base.version:           4.2.2
 # Uncomment the following line to build the non-snapshot version.


### PR DESCRIPTION
This is not directly the same as the patch we
did in the master because it had public API and
the code had significantly changed since this release.

Now has a global propert -x-max-concurrent-connections
and it limits all connections. The current master
can have different values for different servers.